### PR TITLE
refactor: separate platform plugins into different jslibs

### DIFF
--- a/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib
@@ -1,0 +1,27 @@
+mergeInto(LibraryManager.library, {
+
+  ShowInterstitialAdAdSense: function (type, name, beforeAdCallback, afterAdCallback, adBreakDoneCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
+    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
+    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
+    Module.Wortal.noShowPointerAdSense = noShowCallback;
+    showInterstitialAdAdSense(UTF8ToString(type), UTF8ToString(name));
+  },
+
+  RequestRewardedAdAdSense: function (name, beforeAdCallback, afterAdCallback, adBreakDoneCallback, beforeRewardCallback,
+                                      adDismissedCallback, adViewedCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
+    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
+    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
+    Module.Wortal.beforeRewardPointerAdSense = beforeRewardCallback;
+    Module.Wortal.adDismissedPointerAdSense = adDismissedCallback;
+    Module.Wortal.adViewedPointerAdSense = adViewedCallback;
+    Module.Wortal.noShowPointerAdSense = noShowCallback;
+    showRewardedAdAdSense('reward', UTF8ToString(name));
+  },
+
+  ShowRewardedAdAdSense: function () {
+    triggerShowRewardedAdFn();
+  },
+
+};

--- a/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib.meta
+++ b/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9adfcb84c38b4658902f84a366078f1f
+timeCreated: 1660029717

--- a/Assets/DigitalWill/Wortal/Plugins/Link.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/Link.jslib
@@ -1,0 +1,19 @@
+mergeInto(LibraryManager.library, {
+
+  ShowInterstitialAdLink: function(type, placementId, beforeAdCallback, afterAdCallback, noBreakCallback) {
+    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
+    Module.Wortal.afterAdPointerLink = afterAdCallback;
+    Module.Wortal.noBreakPointerLink = noBreakCallback;
+    showInterstitialAdLink(UTF8ToString(type), UTF8ToString(placementId));
+  },
+
+  ShowRewardedAdLink: function(placementId, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noBreakCallback) {
+    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
+    Module.Wortal.afterAdPointerLink = afterAdCallback;
+    Module.Wortal.adDismissedPointerLink = adDismissedCallback;
+    Module.Wortal.adViewedPointerLink = adViewedCallback;
+    Module.Wortal.noBreakPointerLink = noShowCallback;
+    showRewardedAdLink('reward', UTF8ToString(placementId));
+  },
+
+};

--- a/Assets/DigitalWill/Wortal/Plugins/Link.jslib.meta
+++ b/Assets/DigitalWill/Wortal/Plugins/Link.jslib.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b247927f1e56405a9610ab391e36eeb8
+timeCreated: 1660029764

--- a/Assets/DigitalWill/Wortal/Plugins/WortalPlugin.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/WortalPlugin.jslib
@@ -21,44 +21,4 @@ mergeInto(LibraryManager.library, {
     window.open(url, '_blank');
   },
 
-  ShowInterstitialAdAdSense: function(type, name, beforeAdCallback, afterAdCallback, adBreakDoneCallback, noShowCallback) {
-    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
-    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
-    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
-    Module.Wortal.noShowPointerAdSense = noShowCallback;
-    showInterstitialAdAdSense(UTF8ToString(type), UTF8ToString(name));
-  },
-
-  RequestRewardedAdAdSense: function(name, beforeAdCallback, afterAdCallback, adBreakDoneCallback, beforeRewardCallback,
-                                     adDismissedCallback, adViewedCallback, noShowCallback) {
-    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
-    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
-    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
-    Module.Wortal.beforeRewardPointerAdSense = beforeRewardCallback;
-    Module.Wortal.adDismissedPointerAdSense = adDismissedCallback;
-    Module.Wortal.adViewedPointerAdSense = adViewedCallback;
-    Module.Wortal.noShowPointerAdSense = noShowCallback;
-    showRewardedAdAdSense('reward', UTF8ToString(name));
-  },
-
-  ShowRewardedAdAdSense: function () {
-    triggerShowRewardedAdFn();
-  },
-
-  ShowInterstitialAdLink: function(type, placementId, beforeAdCallback, afterAdCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
-    Module.Wortal.afterAdPointerLink = afterAdCallback;
-    Module.Wortal.noBreakPointerLink = noBreakCallback;
-    showInterstitialAdLink(UTF8ToString(type), UTF8ToString(placementId));
-  },
-
-  ShowRewardedAdLink: function(placementId, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
-    Module.Wortal.afterAdPointerLink = afterAdCallback;
-    Module.Wortal.adDismissedPointerLink = adDismissedCallback;
-    Module.Wortal.adViewedPointerLink = adViewedCallback;
-    Module.Wortal.noBreakPointerLink = noShowCallback;
-    showRewardedAdLink('reward', UTF8ToString(placementId));
-  },
-
 });


### PR DESCRIPTION
This PR separates the different platform calls into individual `.jslib` plugins. This is so we can maintain them easier and keep the plugins focused on the platform they are serving for. As we build out the plugins to support the full APIs of each SDK, these plugins will grow significantly.