### PR TITLE
refactor: consolidate pointers and delegates

### DIFF
--- a/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/AdSense.jslib
@@ -1,22 +1,22 @@
 mergeInto(LibraryManager.library, {
 
   ShowInterstitialAdAdSense: function (type, description, beforeAdCallback, afterAdCallback, adBreakDoneCallback, noShowCallback) {
-    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
-    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
-    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
-    Module.Wortal.noShowPointerAdSense = noShowCallback;
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.adBreakDonePointer = adBreakDoneCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showInterstitialAdAdSense(UTF8ToString(type), UTF8ToString(description));
   },
 
   RequestRewardedAdAdSense: function (description, beforeAdCallback, afterAdCallback, adBreakDoneCallback, beforeRewardCallback,
                                       adDismissedCallback, adViewedCallback, noShowCallback) {
-    Module.Wortal.beforeAdPointerAdSense = beforeAdCallback;
-    Module.Wortal.afterAdPointerAdSense = afterAdCallback;
-    Module.Wortal.adBreakDonePointerAdSense = adBreakDoneCallback;
-    Module.Wortal.beforeRewardPointerAdSense = beforeRewardCallback;
-    Module.Wortal.adDismissedPointerAdSense = adDismissedCallback;
-    Module.Wortal.adViewedPointerAdSense = adViewedCallback;
-    Module.Wortal.noShowPointerAdSense = noShowCallback;
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.adBreakDonePointer = adBreakDoneCallback;
+    Module.Wortal.beforeRewardPointer = beforeRewardCallback;
+    Module.Wortal.adDismissedPointer = adDismissedCallback;
+    Module.Wortal.adViewedPointer = adViewedCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showRewardedAdAdSense('reward', UTF8ToString(description));
   },
 

--- a/Assets/DigitalWill/Wortal/Plugins/Link.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/Link.jslib
@@ -16,19 +16,19 @@ mergeInto(LibraryManager.library, {
     });
   },
 
-  ShowInterstitialAdLink: function(type, adUnitId, description, beforeAdCallback, afterAdCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
-    Module.Wortal.afterAdPointerLink = afterAdCallback;
-    Module.Wortal.noBreakPointerLink = noBreakCallback;
+  ShowInterstitialAdLink: function(type, adUnitId, description, beforeAdCallback, afterAdCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showInterstitialAdLink(UTF8ToString(type), UTF8ToString(adUnitId), UTF8ToString(description));
   },
 
-  ShowRewardedAdLink: function(adUnitId, description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerLink = beforeAdCallback;
-    Module.Wortal.afterAdPointerLink = afterAdCallback;
-    Module.Wortal.adDismissedPointerLink = adDismissedCallback;
-    Module.Wortal.adViewedPointerLink = adViewedCallback;
-    Module.Wortal.noBreakPointerLink = noShowCallback;
+  ShowRewardedAdLink: function(adUnitId, description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.adDismissedPointer = adDismissedCallback;
+    Module.Wortal.adViewedPointer = adViewedCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showRewardedAdLink('reward', UTF8ToString(adUnitId), UTF8ToString(description));
   },
 

--- a/Assets/DigitalWill/Wortal/Plugins/Viber.jslib
+++ b/Assets/DigitalWill/Wortal/Plugins/Viber.jslib
@@ -1,18 +1,18 @@
 mergeInto(LibraryManager.library, {
 
-  ShowInterstitialAdViber: function(type, adUnitId, description, beforeAdCallback, afterAdCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerViber = beforeAdCallback;
-    Module.Wortal.afterAdPointerViber = afterAdCallback;
-    Module.Wortal.noBreakPointerViber = noBreakCallback;
+  ShowInterstitialAdViber: function(type, adUnitId, description, beforeAdCallback, afterAdCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showInterstitialAdViber(UTF8ToString(type), UTF8ToString(adUnitId), UTF8ToString(description));
   },
 
-  ShowRewardedAdViber: function(adUnitId, description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noBreakCallback) {
-    Module.Wortal.beforeAdPointerViber = beforeAdCallback;
-    Module.Wortal.afterAdPointerViber = afterAdCallback;
-    Module.Wortal.adDismissedPointerViber = adDismissedCallback;
-    Module.Wortal.adViewedPointerViber = adViewedCallback;
-    Module.Wortal.noBreakPointerViber = noShowCallback;
+  ShowRewardedAdViber: function(adUnitId, description, beforeAdCallback, afterAdCallback, adDismissedCallback, adViewedCallback, noShowCallback) {
+    Module.Wortal.beforeAdPointer = beforeAdCallback;
+    Module.Wortal.afterAdPointer = afterAdCallback;
+    Module.Wortal.adDismissedPointer = adDismissedCallback;
+    Module.Wortal.adViewedPointer = adViewedCallback;
+    Module.Wortal.noShowPointer = noShowCallback;
     showRewardedAdViber('reward', UTF8ToString(adUnitId), UTF8ToString(description));
   },
 

--- a/Assets/DigitalWill/Wortal/Plugins/Wortal.jspre
+++ b/Assets/DigitalWill/Wortal/Plugins/Wortal.jspre
@@ -1,69 +1,33 @@
 Module['Wortal'] = Module['Wortal'] || {};
 
-Module['Wortal'].TriggerBeforeAdAdSense = function() {
-  dynCall_v(Module.Wortal.beforeAdPointerAdSense);
+// Global pointers
+
+Module['Wortal'].TriggerBeforeAd = function() {
+  dynCall_v(Module.Wortal.beforeAdPointer);
 }
 
-Module['Wortal'].TriggerAfterAdAdSense = function() {
-  dynCall_v(Module.Wortal.afterAdPointerAdSense);
+Module['Wortal'].TriggerAfterAd = function() {
+  dynCall_v(Module.Wortal.afterAdPointer);
 }
 
-Module['Wortal'].TriggerAdBreakDoneAdSense = function() {
-  dynCall_v(Module.Wortal.adBreakDonePointerAdSense);
+Module['Wortal'].TriggerAdDismissed = function() {
+  dynCall_v(Module.Wortal.adDismissedPointer);
 }
 
-Module['Wortal'].TriggerBeforeRewardAdSense = function() {
-  dynCall_v(Module.Wortal.beforeRewardPointerAdSense);
+Module['Wortal'].TriggerAdViewed = function() {
+  dynCall_v(Module.Wortal.adViewedPointer);
 }
 
-Module['Wortal'].TriggerAdDismissedAdSense = function() {
-  dynCall_v(Module.Wortal.adDismissedPointerAdSense);
+Module['Wortal'].TriggerNoShow = function() {
+  dynCall_v(Module.Wortal.noShowPointer);
 }
 
-Module['Wortal'].TriggerAdViewedAdSense = function() {
-  dynCall_v(Module.Wortal.adViewedPointerAdSense);
+// AdSense specific pointers
+
+Module['Wortal'].TriggerAdBreakDone = function() {
+  dynCall_v(Module.Wortal.adBreakDonePointer);
 }
 
-Module['Wortal'].TriggerNoShowAdSense = function() {
-  dynCall_v(Module.Wortal.noShowPointerAdSense);
-}
-
-Module['Wortal'].TriggerBeforeAdLink = function() {
-  dynCall_v(Module.Wortal.beforeAdPointerLink);
-}
-
-Module['Wortal'].TriggerAfterAdLink = function() {
-  dynCall_v(Module.Wortal.afterAdPointerLink);
-}
-
-Module['Wortal'].TriggerAdDismissedLink = function() {
-  dynCall_v(Module.Wortal.adDismissedPointerLink);
-}
-
-Module['Wortal'].TriggerAdViewedLink = function() {
-  dynCall_v(Module.Wortal.adViewedPointerLink);
-}
-
-Module['Wortal'].TriggerNoShowLink = function() {
-  dynCall_v(Module.Wortal.noBreakPointerLink);
-}
-
-Module['Wortal'].TriggerBeforeAdViber = function() {
-  dynCall_v(Module.Wortal.beforeAdPointerViber);
-}
-
-Module['Wortal'].TriggerAfterAdViber = function() {
-  dynCall_v(Module.Wortal.afterAdPointerViber);
-}
-
-Module['Wortal'].TriggerAdDismissedViber = function() {
-  dynCall_v(Module.Wortal.adDismissedPointerViber);
-}
-
-Module['Wortal'].TriggerAdViewedViber = function() {
-  dynCall_v(Module.Wortal.adViewedPointerViber);
-}
-
-Module['Wortal'].TriggerNoShowViber = function() {
-  dynCall_v(Module.Wortal.noBreakPointerViber);
+Module['Wortal'].TriggerBeforeReward = function() {
+  dynCall_v(Module.Wortal.beforeRewardPointer);
 }

--- a/Assets/DigitalWill/Wortal/Plugins/Wortal.jspre.meta
+++ b/Assets/DigitalWill/Wortal/Plugins/Wortal.jspre.meta
@@ -1,3 +1,32 @@
 fileFormatVersion: 2
 guid: 9702efab857547d4830f2103e127b4cf
-timeCreated: 1659938750
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/AdSense.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/AdSense.cs
@@ -12,13 +12,8 @@ namespace DigitalWill
     {
         private static bool _isAdEventTriggered;
 
-        private delegate void BeforeAdDelegate();
-        private delegate void AfterAdDelegate();
         private delegate void AdBreakDoneDelegate();
         private delegate void BeforeRewardDelegate();
-        private delegate void AdDismissedDelegate();
-        private delegate void AdViewedDelegate();
-        private delegate void NoShowDelegate();
 
         public void ShowInterstitialAd(Placement type, string description)
         {
@@ -69,28 +64,28 @@ namespace DigitalWill
 
         [DllImport("__Internal")]
         private static extern void ShowInterstitialAdAdSense(string type, string name,
-                                                             BeforeAdDelegate beforeAdCallback,
-                                                             AfterAdDelegate afterAdCallback,
+                                                             IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                             IAdProvider.AfterAdDelegate afterAdCallback,
                                                              AdBreakDoneDelegate adBreakDoneDelegate,
-                                                             NoShowDelegate noShowDelegate);
+                                                             IAdProvider.NoShowDelegate noShowDelegate);
 
         [DllImport("__Internal")]
-        private static extern void RequestRewardedAdAdSense(string name, BeforeAdDelegate beforeAdCallback,
-                                                            AfterAdDelegate afterAdCallback,
+        private static extern void RequestRewardedAdAdSense(string name, IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                            IAdProvider.AfterAdDelegate afterAdCallback,
                                                             AdBreakDoneDelegate adBreakDoneDelegate,
                                                             BeforeRewardDelegate beforeRewardDelegate,
-                                                            AdDismissedDelegate adDismissedDelegate,
-                                                            AdViewedDelegate adViewedDelegate,
-                                                            NoShowDelegate noShowDelegate);
+                                                            IAdProvider.AdDismissedDelegate adDismissedDelegate,
+                                                            IAdProvider.AdViewedDelegate adViewedDelegate,
+                                                            IAdProvider.NoShowDelegate noShowDelegate);
 
-        [MonoPInvokeCallback(typeof(BeforeAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.BeforeAdDelegate))]
         private static void BeforeAdCallback()
         {
             Debug.Log("[Wortal] BeforeAdCallback");
             Wortal.CallBeforeAd();
         }
 
-        [MonoPInvokeCallback(typeof(AfterAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AfterAdDelegate))]
         private static void AfterAdCallback()
         {
             // We don't trigger an event here because it's redundant. If this is called, AdBreakDone will be called
@@ -120,21 +115,21 @@ namespace DigitalWill
             ShowRewardedAdAdSense();
         }
 
-        [MonoPInvokeCallback(typeof(AdDismissedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdDismissedDelegate))]
         private static void AdDismissedCallback()
         {
             Debug.Log("[Wortal] AdDismissedCallback");
             Wortal.CallAdDismissed();
         }
 
-        [MonoPInvokeCallback(typeof(AdViewedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdViewedDelegate))]
         private static void AdViewedCallback()
         {
             Debug.Log("[Wortal] AdViewedCallback");
             Wortal.CallAdViewed();
         }
 
-        [MonoPInvokeCallback(typeof(NoShowDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.NoShowDelegate))]
         private static void NoShowCallback()
         {
             // We check this because if AdSense decides not to show the player an ad, we'll receive an AdBreakDone

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/IAdProvider.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/IAdProvider.cs
@@ -5,6 +5,12 @@ namespace DigitalWill
     /// </summary>
     public interface IAdProvider
     {
+        public delegate void BeforeAdDelegate();
+        public delegate void AfterAdDelegate();
+        public delegate void AdDismissedDelegate();
+        public delegate void AdViewedDelegate();
+        public delegate void NoShowDelegate();
+
         /// <summary>
         /// Shows an interstitial ad.
         /// </summary>

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/Link.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/Link.cs
@@ -9,12 +9,6 @@ namespace DigitalWill
     /// </summary>
     internal class Link : IAdProvider
     {
-        private delegate void BeforeAdDelegate();
-        private delegate void AfterAdDelegate();
-        private delegate void AdDismissedDelegate();
-        private delegate void AdViewedDelegate();
-        private delegate void NoShowDelegate();
-
         public void ShowInterstitialAd(Placement type, string description)
         {
             string adUnitId = Wortal.Settings.LinkInterstitialId;
@@ -74,46 +68,46 @@ namespace DigitalWill
 
         [DllImport("__Internal")]
         private static extern void ShowInterstitialAdLink(string type, string adUnitId, string description,
-                                                             BeforeAdDelegate beforeAdCallback,
-                                                             AfterAdDelegate afterAdCallback,
-                                                             NoShowDelegate noShowDelegate);
+                                                             IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                             IAdProvider.AfterAdDelegate afterAdCallback,
+                                                             IAdProvider.NoShowDelegate noShowDelegate);
 
         [DllImport("__Internal")]
-        private static extern void ShowRewardedAdLink(string adUnitId, string description, BeforeAdDelegate beforeAdCallback,
-                                                            AfterAdDelegate afterAdCallback,
-                                                            AdDismissedDelegate adDismissedDelegate,
-                                                            AdViewedDelegate adViewedDelegate,
-                                                            NoShowDelegate noShowDelegate);
+        private static extern void ShowRewardedAdLink(string adUnitId, string description, IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                            IAdProvider.AfterAdDelegate afterAdCallback,
+                                                            IAdProvider.AdDismissedDelegate adDismissedDelegate,
+                                                            IAdProvider.AdViewedDelegate adViewedDelegate,
+                                                            IAdProvider.NoShowDelegate noShowDelegate);
 
-        [MonoPInvokeCallback(typeof(BeforeAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.BeforeAdDelegate))]
         private static void BeforeAdCallback()
         {
             Debug.Log("[Wortal] BeforeAdCallback");
             Wortal.CallBeforeAd();
         }
 
-        [MonoPInvokeCallback(typeof(AfterAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AfterAdDelegate))]
         private static void AfterAdCallback()
         {
             Debug.Log("[Wortal] AfterAdCallback");
             Wortal.CallAdDone();
         }
 
-        [MonoPInvokeCallback(typeof(AdDismissedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdDismissedDelegate))]
         private static void AdDismissedCallback()
         {
             Debug.Log("[Wortal] AdDismissedCallback");
             Wortal.CallAdDismissed();
         }
 
-        [MonoPInvokeCallback(typeof(AdViewedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdViewedDelegate))]
         private static void AdViewedCallback()
         {
             Debug.Log("[Wortal] AdViewedCallback");
             Wortal.CallAdViewed();
         }
 
-        [MonoPInvokeCallback(typeof(NoShowDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.NoShowDelegate))]
         private static void NoShowCallback()
         {
             Debug.Log("[Wortal] NoShowCallback");

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/Viber.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/Viber.cs
@@ -9,12 +9,6 @@ namespace DigitalWill
 	/// </summary>
 	public class Viber : IAdProvider
 	{
-        private delegate void BeforeAdDelegate();
-        private delegate void AfterAdDelegate();
-        private delegate void AdDismissedDelegate();
-        private delegate void AdViewedDelegate();
-        private delegate void NoShowDelegate();
-
         public void ShowInterstitialAd(Placement type, string description)
         {
             Debug.Log("[Wortal] Ads currently not supported on Viber.");
@@ -79,46 +73,46 @@ namespace DigitalWill
 
         [DllImport("__Internal")]
         private static extern void ShowInterstitialAdViber(string type, string adUnitId, string description,
-                                                             BeforeAdDelegate beforeAdCallback,
-                                                             AfterAdDelegate afterAdCallback,
-                                                             NoShowDelegate noShowDelegate);
+                                                             IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                             IAdProvider.AfterAdDelegate afterAdCallback,
+                                                             IAdProvider.NoShowDelegate noShowDelegate);
 
         [DllImport("__Internal")]
-        private static extern void ShowRewardedAdViber(string adUnitId, string description, BeforeAdDelegate beforeAdCallback,
-                                                            AfterAdDelegate afterAdCallback,
-                                                            AdDismissedDelegate adDismissedDelegate,
-                                                            AdViewedDelegate adViewedDelegate,
-                                                            NoShowDelegate noShowDelegate);
+        private static extern void ShowRewardedAdViber(string adUnitId, string description, IAdProvider.BeforeAdDelegate beforeAdCallback,
+                                                            IAdProvider.AfterAdDelegate afterAdCallback,
+                                                            IAdProvider.AdDismissedDelegate adDismissedDelegate,
+                                                            IAdProvider.AdViewedDelegate adViewedDelegate,
+                                                            IAdProvider.NoShowDelegate noShowDelegate);
 
-        [MonoPInvokeCallback(typeof(BeforeAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.BeforeAdDelegate))]
         private static void BeforeAdCallback()
         {
             Debug.Log("[Wortal] BeforeAdCallback");
             Wortal.CallBeforeAd();
         }
 
-        [MonoPInvokeCallback(typeof(AfterAdDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AfterAdDelegate))]
         private static void AfterAdCallback()
         {
             Debug.Log("[Wortal] AfterAdCallback");
             Wortal.CallAdDone();
         }
 
-        [MonoPInvokeCallback(typeof(AdDismissedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdDismissedDelegate))]
         private static void AdDismissedCallback()
         {
             Debug.Log("[Wortal] AdDismissedCallback");
             Wortal.CallAdDismissed();
         }
 
-        [MonoPInvokeCallback(typeof(AdViewedDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.AdViewedDelegate))]
         private static void AdViewedCallback()
         {
             Debug.Log("[Wortal] AdViewedCallback");
             Wortal.CallAdViewed();
         }
 
-        [MonoPInvokeCallback(typeof(NoShowDelegate))]
+        [MonoPInvokeCallback(typeof(IAdProvider.NoShowDelegate))]
         private static void NoShowCallback()
         {
             Debug.Log("[Wortal] NoShowCallback");

--- a/Assets/WebGLTemplates/Wortal/assets/js/ads-adsense.js
+++ b/Assets/WebGLTemplates/Wortal/assets/js/ads-adsense.js
@@ -3,16 +3,16 @@ var showRewardedAdFn;
 function showInterstitialAdAdSense(type, name) {
   window.triggerWortalAd(type, "", name, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdAdSense();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdAdSense();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     adBreakDone: (placementInfo) => {
-      gameInstance.Module.Wortal.TriggerAdBreakDoneAdSense();
+      gameInstance.Module.Wortal.TriggerAdBreakDone();
     },
     noShow: () => {
-      gameInstance.Module.Wortal.TriggerNoShowAdSense();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }
@@ -20,26 +20,26 @@ function showInterstitialAdAdSense(type, name) {
 function showRewardedAdAdSense(name) {
   window.triggerWortalAd('reward', "", name, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdAdSense();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdAdSense();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     adBreakDone: (placementInfo) => {
-      gameInstance.Module.Wortal.TriggerAdBreakDoneAdSense();
+      gameInstance.Module.Wortal.TriggerAdBreakDone();
     },
     beforeReward: (showAdFn) => {
       showRewardedAdFn = showAdFn;
-      gameInstance.Module.Wortal.TriggerBeforeRewardAdSense();
+      gameInstance.Module.Wortal.TriggerBeforeReward();
     },
     adDismissed: () => {
-      gameInstance.Module.Wortal.TriggerAdDismissedAdSense();
+      gameInstance.Module.Wortal.TriggerAdDismissed();
     },
     adViewed: () => {
-      gameInstance.Module.Wortal.TriggerAdViewedAdSense();
+      gameInstance.Module.Wortal.TriggerAdViewed();
     },
     noShow: () => {
-      gameInstance.Module.Wortal.TriggerNoShowAdSense();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }

--- a/Assets/WebGLTemplates/Wortal/assets/js/ads-link.js
+++ b/Assets/WebGLTemplates/Wortal/assets/js/ads-link.js
@@ -1,13 +1,13 @@
 function showInterstitialAdLink(type, adUnitId, description) {
   window.triggerWortalAd(type, adUnitId, description, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdLink();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdLink();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     noBreak: () => {
-      gameInstance.Module.Wortal.TriggerNoShowLink();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }
@@ -15,19 +15,19 @@ function showInterstitialAdLink(type, adUnitId, description) {
 function showRewardedAdLink(adUnitId, description) {
   window.triggerWortalAd('reward', adUnitId, description, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdLink();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdLink();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     adDismissed: () => {
-      gameInstance.Module.Wortal.TriggerAdDismissedLink();
+      gameInstance.Module.Wortal.TriggerAdDismissed();
     },
     adViewed: () => {
-      gameInstance.Module.Wortal.TriggerAdViewedLink();
+      gameInstance.Module.Wortal.TriggerAdViewed();
     },
     noBreak: () => {
-      gameInstance.Module.Wortal.TriggerNoShowLink();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }

--- a/Assets/WebGLTemplates/Wortal/assets/js/ads-viber.js
+++ b/Assets/WebGLTemplates/Wortal/assets/js/ads-viber.js
@@ -1,13 +1,13 @@
 function showInterstitialAdViber(type, adUnitId, description) {
   window.triggerWortalAd(type, adUnitId, description, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdViber();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdViber();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     noBreak: () => {
-      gameInstance.Module.Wortal.TriggerNoShowViber();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }
@@ -15,19 +15,19 @@ function showInterstitialAdViber(type, adUnitId, description) {
 function showRewardedAdViber(adUnitId, description) {
   window.triggerWortalAd('reward', adUnitId, description, {
     beforeAd: () => {
-      gameInstance.Module.Wortal.TriggerBeforeAdViber();
+      gameInstance.Module.Wortal.TriggerBeforeAd();
     },
     afterAd: () => {
-      gameInstance.Module.Wortal.TriggerAfterAdViber();
+      gameInstance.Module.Wortal.TriggerAfterAd();
     },
     adDismissed: () => {
-      gameInstance.Module.Wortal.TriggerAdDismissedViber();
+      gameInstance.Module.Wortal.TriggerAdDismissed();
     },
     adViewed: () => {
-      gameInstance.Module.Wortal.TriggerAdViewedViber();
+      gameInstance.Module.Wortal.TriggerAdViewed();
     },
     noBreak: () => {
-      gameInstance.Module.Wortal.TriggerNoShowViber();
+      gameInstance.Module.Wortal.TriggerNoShow();
     },
   });
 }


### PR DESCRIPTION
This refactor was to clean up the plugin code and reuse pointers and delegates that are common to all implementations.

* Platform specific pointers were removed
* Global delegates were added to IAdProvider