### PR TITLE
refactor: revised css stylesheet

### DIFF
--- a/Assets/WebGLTemplates/Wortal/assets/css/style.css
+++ b/Assets/WebGLTemplates/Wortal/assets/css/style.css
@@ -1,26 +1,47 @@
-* {
-  font-family: monospace;
-}
-
-body {
-  background: #000;
-  color: #999;
-  font-size: 17px;
-  height: 100vh;
-  overflow: hidden;
-}
-
-a {
-  color: #ccc;
-  text-decoration: underline;
-}
-
-.info {
-  width: 100%;
-  padding: 12px;
+/************************
+Wortal template CSS settings
+*************************
+If you force the game into portrait/landscape then you should set a background image in the canvas to fill
+in the blank spaces in the desktop view of the game. The default is to stretch the game to fill the iframe the
+game is rendered in.. which is 700x500px as of v4.1.0.
+************************/
+html {
   box-sizing: border-box;
 }
 
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+html, body {
+  height: 100%;
+}
+
+canvas {
+  display: block;
+}
+
+body {
+  margin: 0;
+}
+
+#unity-container {
+  width: 100%;
+  height: 100%;
+}
+
+#unity-canvas {
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+
+/************************
+This should be left as is.
+AdSense pre-rolls require the game to not be shown until after the ad has finished.
+For Wortal deployment this is disabled in the pre-roll callback.
+For Link and Viber deployments this is disabled immediately after initializing Wortal SDK as we hook into their loading screen.
+************************/
 .loading-cover {
   background: #000000;
   width: 100%;
@@ -33,51 +54,14 @@ a {
   z-index: 100;
 }
 
-/* WebGL layout */
-
-.webgl-wrapper {
-  display: block;
-  height: 100vh;
-  width: 47.5vh;
-  position: relative;
-  margin: 0 auto auto;
-}
-
-.webgl-content {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
-#unityContainer {
-  width: 100%;
-  height: 100%;
-}
-
-.webgl-content * {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-#unityContainer canvas {
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-}
-
-/* This element makes sure we preserve 9:16 aspect ratio. */
-
-.aspect {
-  margin-top: calc(100% / 270 * 480);
-}
-
-/* Progress bar */
-
-.webgl-content .logo, .progress {
+/************************
+Feel free to modify this to suit your game's needs.
+Will not be shown during Link and Viber deployments as they require the game to use their loading screen.
+************************/
+.progress {
+  height: 18px;
+  width: 141px;
+  margin-top: 90px;
   position: absolute;
   left: 50%;
   top: 50%;
@@ -85,19 +69,7 @@ a {
   transform: translate(-50%, -50%);
 }
 
-.webgl-content .logo {
-  background: url('../images/progressLogo.Light.png') no-repeat center / contain;
-  width: 154px;
-  height: 130px;
-}
-
-.webgl-content .progress {
-  height: 18px;
-  width: 141px;
-  margin-top: 90px;
-}
-
-.webgl-content .progress .empty {
+.progress .empty {
   background: url('../images/progressEmpty.Light.png') no-repeat right / cover;
   float: right;
   width: 100%;
@@ -105,7 +77,7 @@ a {
   display: inline-block;
 }
 
-.webgl-content .progress .full {
+.progress .full {
   background: url('../images/progressFull.Light.png') no-repeat left / cover;
   float: left;
   width: 0;
@@ -113,46 +85,10 @@ a {
   display: inline-block;
 }
 
-.webgl-content .logo.Dark {
-  background-image: url('../images/progressLogo.Dark.png');
-}
-
-.webgl-content .progress.Dark .empty {
+.progress.Dark .empty {
   background-image: url('../images/progressEmpty.Dark.png');
 }
 
-.webgl-content .progress.Dark .full {
+.progress.Dark .full {
   background-image: url('../images/progressFull.Dark.png');
-}
-
-.webgl-content .footer {
-  margin-top: 5px;
-  height: 38px;
-  line-height: 38px;
-  font-family: Helvetica, Verdana, Arial, sans-serif;
-  font-size: 18px;
-}
-
-.webgl-content .footer .webgl-logo, .title, .fullscreen {
-  height: 100%;
-  display: inline-block;
-  background: transparent center no-repeat;
-}
-
-.webgl-content .footer .webgl-logo {
-  background-image: url('../images/webgl-logo.png');
-  width: 204px;
-  float: left;
-}
-
-.webgl-content .footer .title {
-  margin-right: 10px;
-  float: right;
-}
-
-.webgl-content .footer .fullscreen {
-  background-image: url('../images/fullscreen.png');
-  width: 38px;
-  float: right;
-  cursor: pointer;
 }

--- a/Assets/WebGLTemplates/Wortal/index.html
+++ b/Assets/WebGLTemplates/Wortal/index.html
@@ -5,7 +5,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <link rel="stylesheet" href="assets/css/reset.css">
   <link rel="stylesheet" href="assets/css/style.css">
 
   <title>{{{ PRODUCT_NAME }}}</title>
@@ -14,17 +13,11 @@
 </head>
 <body>
 <div class="loading-cover" id="loading-cover"></div>
-<div class="webgl-wrapper">
-  <div class="webgl-content">
-    <div id="progress" class="progress Dark">
-      <div class="empty">
-        <div id="progressBar" class="full"></div>
-      </div>
-    </div>
-    <div id="unityContainer">
-      <canvas id="unity-canvas" style="background: {{{ BACKGROUND_FILENAME ? 'url(\'Build/' + BACKGROUND_FILENAME.replace(/'/g, '%27') + '\') center / cover' : BACKGROUND_COLOR }}}"></canvas>
-    </div>
-  </div>
+<div id="progress" class="progress Dark">
+  <div id="progressBar" class="full"></div>
+</div>
+<div id="unity-container" class="unity-desktop">
+  <canvas id="unity-canvas" style="background: {{{ BACKGROUND_FILENAME ? 'url(\'Build/' + BACKGROUND_FILENAME.replace(/'/g, '%27') + '\') center / cover' : BACKGROUND_COLOR }}}"></canvas>
 </div>
 <script src="Build/{{{ LOADER_FILENAME }}}"></script>
 <script src="assets/js/wortal-loader.js"></script>


### PR DESCRIPTION
This refactored the `style.css` sheet and removes `reset.css`. It removes the requirement for 9:16 that was inadvertently left in. This should stretch the game to fit the desktop view, which may distort poorly designed UIs, but provides a much better overall presentation on desktop while maintaining mobile friendly views.

* Removed webgl divs
* Removed forced aspect ratio (why was it there?)
* Added comments