### PR TITLE
refactor: remove ad timed out event

### DIFF
--- a/Assets/DigitalWill/Wortal/Runtime/Ads/AdSense.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/AdSense.cs
@@ -97,7 +97,7 @@ namespace DigitalWill
         private static void AdBreakDoneCallback()
         {
             Debug.Log("[Wortal] AdBreakDoneCallback");
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
 
             // If AdSense doesn't serve an ad, we'll still receive this callback, but the Wortal SDK will have
             // triggered a 500ms timeout before it triggers the NoShow callback. We set this flag to avoid firing
@@ -142,7 +142,7 @@ namespace DigitalWill
             }
 
             Debug.Log("[Wortal] NoShowCallback");
-            Wortal.CallAdTimedOut();
+            Wortal.CallAfterAd();
         }
     }
 }

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/DebugAds.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/DebugAds.cs
@@ -9,7 +9,7 @@ namespace DigitalWill
         public void ShowInterstitialAd(Placement type, string name)
         {
             Wortal.CallBeforeAd();
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace DigitalWill
                     break;
             }
 
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
         }
     }
 }

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/Link.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/Link.cs
@@ -90,7 +90,7 @@ namespace DigitalWill
         private static void AfterAdCallback()
         {
             Debug.Log("[Wortal] AfterAdCallback");
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
         }
 
         [MonoPInvokeCallback(typeof(IAdProvider.AdDismissedDelegate))]
@@ -111,7 +111,7 @@ namespace DigitalWill
         private static void NoShowCallback()
         {
             Debug.Log("[Wortal] NoShowCallback");
-            Wortal.CallAdTimedOut();
+            Wortal.CallAfterAd();
         }
     }
 }

--- a/Assets/DigitalWill/Wortal/Runtime/Ads/Viber.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Ads/Viber.cs
@@ -13,7 +13,7 @@ namespace DigitalWill
         {
             Debug.Log("[Wortal] Ads currently not supported on Viber.");
             Wortal.CallBeforeAd();
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
 
             //TODO: finish implementation when Viber ads are supported
 /*
@@ -54,7 +54,7 @@ namespace DigitalWill
             Debug.Log("[Wortal] Ads currently not supported on Viber.");
             Wortal.CallBeforeAd();
             Wortal.CallAdDismissed();
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
 
             //TODO: finish implementation when Viber ads are supported
 /*
@@ -95,7 +95,7 @@ namespace DigitalWill
         private static void AfterAdCallback()
         {
             Debug.Log("[Wortal] AfterAdCallback");
-            Wortal.CallAdDone();
+            Wortal.CallAfterAd();
         }
 
         [MonoPInvokeCallback(typeof(IAdProvider.AdDismissedDelegate))]
@@ -116,7 +116,7 @@ namespace DigitalWill
         private static void NoShowCallback()
         {
             Debug.Log("[Wortal] NoShowCallback");
-            Wortal.CallAdTimedOut();
+            Wortal.CallAfterAd();
         }
     }
 }

--- a/Assets/DigitalWill/Wortal/Runtime/Wortal.cs
+++ b/Assets/DigitalWill/Wortal/Runtime/Wortal.cs
@@ -24,19 +24,15 @@ namespace DigitalWill
         /// An ad request has finished. This does not guarantee an ad was shown, only that the request to the provider
         /// has finished and the player can resume the game now.
         /// </summary>
-        public static event Action AdDone;
-        /// <summary>
-        /// A timeout was reached before an ad was shown. This is possibly due to ad blockers or other browser extensions.
-        /// </summary>
-        public static event Action AdTimedOut;
+        public static event Action AfterAd;
         /// <summary>
         /// A rewarded ad was successfully viewed and the player should be given a reward.
         /// </summary>
-        public static event Action RewardedAdViewed;
+        public static event Action AdViewed;
         /// <summary>
         /// A rewarded ad was dismissed and the player should not receive a reward.
         /// </summary>
-        public static event Action RewardedAdDismissed;
+        public static event Action AdDismissed;
         /// <summary>
         /// Subscribe to be notified when the language has been parsed and set.
         /// </summary>
@@ -99,10 +95,9 @@ namespace DigitalWill
         }
 
         internal static void CallBeforeAd() => BeforeAd?.Invoke();
-        internal static void CallAdDone() => AdDone?.Invoke();
-        internal static void CallAdTimedOut() => AdTimedOut?.Invoke();
-        internal static void CallAdDismissed() => RewardedAdDismissed?.Invoke();
-        internal static void CallAdViewed() => RewardedAdViewed?.Invoke();
+        internal static void CallAfterAd() => AfterAd?.Invoke();
+        internal static void CallAdDismissed() => AdDismissed?.Invoke();
+        internal static void CallAdViewed() => AdViewed?.Invoke();
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Init()


### PR DESCRIPTION
This PR does some refactoring to clean up the API and make it consistent across SDK implementations.

* Shortened rewarded event names
* Changed AdDone to AfterAd for consistency across SDK