### PR TITLE
refactor(core): wrap deserializers in try/catch

### DIFF
--- a/Runtime/Achievements/WortalAchievements.cs
+++ b/Runtime/Achievements/WortalAchievements.cs
@@ -103,7 +103,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void AchievementsGetAchievementsCallback(string achievementsJson)
         {
-            Achievement[] achievements = JsonConvert.DeserializeObject<Achievement[]>(achievementsJson);
+            Achievement[] achievements;
+
+            try
+            {
+                achievements = JsonConvert.DeserializeObject<Achievement[]>(achievementsJson);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getAchievementsCallback?.Invoke(achievements);
         }
 

--- a/Runtime/Context/WortalContext.cs
+++ b/Runtime/Context/WortalContext.cs
@@ -445,7 +445,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void ContextGetPlayersCallback(string players)
         {
-            WortalPlayer[] playersObj = JsonConvert.DeserializeObject<WortalPlayer[]>(players);
+            WortalPlayer[] playersObj;
+
+            try
+            {
+                playersObj = JsonConvert.DeserializeObject<WortalPlayer[]>(players);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getPlayersCallback?.Invoke(playersObj);
         }
 

--- a/Runtime/IAP/WortalIAP.cs
+++ b/Runtime/IAP/WortalIAP.cs
@@ -207,21 +207,72 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void IAPGetCatalogCallback(string catalog)
         {
-            Product[] catalogObj = JsonConvert.DeserializeObject<Product[]>(catalog);
+            Product[] catalogObj;
+
+            try
+            {
+                catalogObj = JsonConvert.DeserializeObject<Product[]>(catalog);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getCatalogCallback?.Invoke(catalogObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void IAPGetPurchasesCallback(string purchases)
         {
-            Purchase[] purchasesObj = JsonConvert.DeserializeObject<Purchase[]>(purchases);
+            Purchase[] purchasesObj;
+
+            try
+            {
+                purchasesObj = JsonConvert.DeserializeObject<Purchase[]>(purchases);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getPurchasesCallback?.Invoke(purchasesObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void IAPMakePurchaseCallback(string purchase)
         {
-            Purchase purchaseObj = JsonConvert.DeserializeObject<Purchase>(purchase);
+            Purchase purchaseObj;
+
+            try
+            {
+                purchaseObj = JsonConvert.DeserializeObject<Purchase>(purchase);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _makePurchaseCallback?.Invoke(purchaseObj);
         }
 

--- a/Runtime/Leaderboard/WortalLeaderboard.cs
+++ b/Runtime/Leaderboard/WortalLeaderboard.cs
@@ -323,28 +323,96 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void LeaderboardGetCallback(string leaderboard)
         {
-            Leaderboard leaderboardObj = JsonConvert.DeserializeObject<Leaderboard>(leaderboard);
+            Leaderboard leaderboardObj;
+
+            try
+            {
+                leaderboardObj = JsonConvert.DeserializeObject<Leaderboard>(leaderboard);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getLeaderboardCallback?.Invoke(leaderboardObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void LeaderboardSendEntryCallback(string entry)
         {
-            LeaderboardEntry entryObj = JsonConvert.DeserializeObject<LeaderboardEntry>(entry);
+            LeaderboardEntry entryObj;
+
+            try
+            {
+                entryObj = JsonConvert.DeserializeObject<LeaderboardEntry>(entry);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _sendEntryCallback?.Invoke(entryObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void LeaderboardGetEntriesCallback(string entries)
         {
-            LeaderboardEntry[] entriesObj = JsonConvert.DeserializeObject<LeaderboardEntry[]>(entries);
+            LeaderboardEntry[] entriesObj;
+
+            try
+            {
+                entriesObj = JsonConvert.DeserializeObject<LeaderboardEntry[]>(entries);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getEntriesCallback?.Invoke(entriesObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void LeaderboardGetPlayerEntryCallback(string entry)
         {
-            LeaderboardEntry entryObj = JsonConvert.DeserializeObject<LeaderboardEntry>(entry);
+            LeaderboardEntry entryObj;
+
+            try
+            {
+                entryObj = JsonConvert.DeserializeObject<LeaderboardEntry>(entry);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getPlayerEntryCallback?.Invoke(entryObj);
         }
 
@@ -357,7 +425,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void LeaderboardGetConnectedPlayersEntriesCallback(string entries)
         {
-            LeaderboardEntry[] entriesObj = JsonConvert.DeserializeObject<LeaderboardEntry[]>(entries);
+            LeaderboardEntry[] entriesObj;
+
+            try
+            {
+                entriesObj = JsonConvert.DeserializeObject<LeaderboardEntry[]>(entries);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getConnectedPlayersEntriesCallback?.Invoke(entriesObj);
         }
 

--- a/Runtime/Notifications/WortalNotifications.cs
+++ b/Runtime/Notifications/WortalNotifications.cs
@@ -174,14 +174,48 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void NotificationsScheduleCallback(string result)
         {
-            NotificationScheduleResult resultObj = JsonConvert.DeserializeObject<NotificationScheduleResult>(result);
+            NotificationScheduleResult resultObj;
+
+            try
+            {
+                resultObj = JsonConvert.DeserializeObject<NotificationScheduleResult>(result);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _scheduleCallback?.Invoke(resultObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void NotificationsGetHistoryCallback(string result)
         {
-            ScheduledNotification[] resultObj = JsonConvert.DeserializeObject<ScheduledNotification[]>(result);
+            ScheduledNotification[] resultObj;
+
+            try
+            {
+                resultObj = JsonConvert.DeserializeObject<ScheduledNotification[]>(result);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getHistoryCallback?.Invoke(resultObj);
         }
 

--- a/Runtime/Player/WortalPlayer.cs
+++ b/Runtime/Player/WortalPlayer.cs
@@ -465,7 +465,24 @@ namespace DigitalWill.WortalSDK
         private static void PlayerGetDataCallback(string data)
         {
             // Data is Record<string, unknown> in JS.
-            IDictionary<string, object> dataObj = JsonConvert.DeserializeObject<JObject>(data).ToDictionary();
+            IDictionary<string, object> dataObj;
+
+            try
+            {
+                dataObj = JsonConvert.DeserializeObject<JObject>(data).ToDictionary();
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getDataCallback?.Invoke(dataObj);
         }
 
@@ -484,7 +501,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void PlayerGetConnectedPlayersCallback(string players)
         {
-            WortalPlayer[] playersObj = JsonConvert.DeserializeObject<WortalPlayer[]>(players);
+            WortalPlayer[] playersObj;
+
+            try
+            {
+                playersObj = JsonConvert.DeserializeObject<WortalPlayer[]>(players);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getConnectedPlayersCallback?.Invoke(playersObj);
         }
 

--- a/Runtime/Stats/WortalStats.cs
+++ b/Runtime/Stats/WortalStats.cs
@@ -113,7 +113,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void StatsGetStatsCallback(string statsJson)
         {
-            Stats[] stats = JsonConvert.DeserializeObject<Stats[]>(statsJson);
+            Stats[] stats;
+
+            try
+            {
+                stats = JsonConvert.DeserializeObject<Stats[]>(statsJson);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getStatsCallback?.Invoke(stats);
         }
 

--- a/Runtime/Tournament/WortalTournament.cs
+++ b/Runtime/Tournament/WortalTournament.cs
@@ -245,14 +245,48 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void TournamentGetCurrentCallback(string tournament)
         {
-            Tournament tournamentObj = JsonConvert.DeserializeObject<Tournament>(tournament);
+            Tournament tournamentObj;
+
+            try
+            {
+                tournamentObj = JsonConvert.DeserializeObject<Tournament>(tournament);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getCurrentCallback?.Invoke(tournamentObj);
         }
 
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void TournamentGetAllCallback(string tournaments)
         {
-            Tournament[] tournamentObj = JsonConvert.DeserializeObject<Tournament[]>(tournaments);
+            Tournament[] tournamentObj;
+
+            try
+            {
+                tournamentObj = JsonConvert.DeserializeObject<Tournament[]>(tournaments);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _getAllCallback?.Invoke(tournamentObj);
         }
 
@@ -265,7 +299,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void TournamentCreateCallback(string tournament)
         {
-            Tournament tournamentObj = JsonConvert.DeserializeObject<Tournament>(tournament);
+            Tournament tournamentObj;
+
+            try
+            {
+                tournamentObj = JsonConvert.DeserializeObject<Tournament>(tournament);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message,
+                };
+
+                Wortal.WortalError?.Invoke(error);
+                return;
+            }
+
             _createCallback?.Invoke(tournamentObj);
         }
 

--- a/Runtime/Wortal.cs
+++ b/Runtime/Wortal.cs
@@ -310,7 +310,21 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void WortalErrorCallback(string error)
         {
-            var wortalError = JsonConvert.DeserializeObject<WortalError>(error);
+            WortalError wortalError;
+
+            try
+            {
+                wortalError = JsonConvert.DeserializeObject<WortalError>(error);
+            }
+            catch (Exception e)
+            {
+                wortalError = new WortalError
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+            }
+
             WortalError?.Invoke(wortalError);
         }
 
@@ -329,7 +343,24 @@ namespace DigitalWill.WortalSDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void AuthenticateCallback(string status)
         {
-            var authResponse = JsonConvert.DeserializeObject<AuthResponse>(status);
+            AuthResponse authResponse;
+
+            try
+            {
+                authResponse = JsonConvert.DeserializeObject<AuthResponse>(status);
+            }
+            catch (Exception e)
+            {
+                WortalError error = new()
+                {
+                    Code = WortalErrorCodes.SERIALIZATION_ERROR.ToString(),
+                    Message = e.Message
+                };
+
+                WortalError?.Invoke(error);
+                return;
+            }
+
             _authenticateCallback?.Invoke(authResponse);
         }
 

--- a/Runtime/WortalErrorCodes.cs
+++ b/Runtime/WortalErrorCodes.cs
@@ -79,5 +79,10 @@
         /// The SDK failed to initialize, this can occur if the Wortal SDK encountered an error during initialization or if the platform SDK failed to initialize.
         /// </summary>
         INITIALIZATION_ERROR,
+        /// <summary>
+        /// The SDK failed to serialize or deserialize an object. This can occur if the object is malformed or does
+        /// not match the intended data type.
+        /// </summary>
+        SERIALIZATION_ERROR,
     }
 }


### PR DESCRIPTION
This PR improves our error handling in the SDK by wrapping deserializers in try/catch blocks to alert us when the deserialization fails. This is particularly important in functions marked with the `[MonoPInvokeCallback]` attribute as these are difficult to debug in the WASM stack.

Also added a new error message specifically for this.